### PR TITLE
Define path to `channels.json` file dynamically

### DIFF
--- a/Slack_Export_Channel_Files.ps1
+++ b/Slack_Export_Channel_Files.ps1
@@ -16,7 +16,7 @@ class File {
 	[string] $DownloadedFilePath
 }
 
-$channelList = Get-Content -Raw -Path .\slackHistory\channels.json | ConvertFrom-Json
+$channelList = Get-Content -Raw -Path "$ExportPath\channels.json" | ConvertFrom-Json
 $Files = New-Object -TypeName System.Collections.ObjectModel.Collection["File"]
 
 Write-Host -ForegroundColor Green "$(Get-TimeStamp) Starting Step 1 (processing channel export for files) of 2. Total Channel Count: $($channelList.Count)"


### PR DESCRIPTION
Now, the script will look for the `channels.json` file in the folder specified by the `$ExportPath` variable, instead of always in the `.\slackHistory` folder.